### PR TITLE
BF: Save recordFrameIntervals in StaticPeriod before disabling.

### DIFF
--- a/psychopy/clock.py
+++ b/psychopy/clock.py
@@ -222,8 +222,8 @@ class StaticPeriod(object):
         self.countdown.reset(duration - self.frameTime)
         # turn off recording of frame intervals throughout static period
         if self.win:
-            self.win.recordFrameIntervals = False
             self._winWasRecordingIntervals = self.win.recordFrameIntervals
+            self.win.recordFrameIntervals = False
 
     def complete(self):
         """Completes the period, using up whatever time is remaining with a


### PR DESCRIPTION
When a `StaticPeriod` starts, the window's `recordFrameIntervals` is set to `False`. After completion, the previous value of `recordFrameIntervals` is restored. However, the order of statements in `StaticPeriod.start()` means that the initial value of `recordFrameIntervals` is always set to `False`, and _then_ saved. By saving before disabling, this initial value will be successfully restored in the future.